### PR TITLE
RTP-8 Configure Checks For Unit Tests

### DIFF
--- a/.github/workflows/client-coverage.yaml
+++ b/.github/workflows/client-coverage.yaml
@@ -1,11 +1,9 @@
 name: client-test-coverage
 on:
   push:
-    paths:
-      - 'client/**'
+    branches: [ "main" ]
   pull_request:
-    paths:
-      - 'client/**'
+    branches: [ "main" ]
 
 jobs:
   coverage:
@@ -47,4 +45,3 @@ jobs:
           name: coverage-report
           path: ./client/coverage
           retention-days: 30
-          

--- a/.github/workflows/client-coverage.yaml
+++ b/.github/workflows/client-coverage.yaml
@@ -21,6 +21,9 @@ jobs:
           node-version: '18'
           cache: 'npm'
           cache-dependency-path: './client/package-lock.json'
+    
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@latest
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/client-coverage.yaml
+++ b/.github/workflows/client-coverage.yaml
@@ -1,0 +1,50 @@
+name: client-test-coverage
+on:
+  push:
+    paths:
+      - 'client/**'
+  pull_request:
+    paths:
+      - 'client/**'
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./client
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: './client/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: npm test -- --browsers=ChromeHeadlessCI --watch=false --code-coverage
+
+      - name: Check coverage thresholds
+        run: |
+          COVERAGE=$(cat ./coverage/coverage-summary.json | jq -r '.total.lines.pct')
+          if (( $(echo "$COVERAGE < 90" | bc -l) )); then
+            echo "Code coverage ($COVERAGE%) is below the required threshold (90%)"
+            exit 1
+          else
+            echo "Code coverage ($COVERAGE%) meets the required threshold (90%)"
+          fi
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: coverage-report
+          path: ./client/coverage
+          retention-days: 30
+          

--- a/.github/workflows/client-coverage.yaml
+++ b/.github/workflows/client-coverage.yaml
@@ -29,7 +29,7 @@ jobs:
         run: npm ci
 
       - name: Run tests with coverage
-        run: npm test -- --browsers=ChromeHeadlessCI --watch=false --code-coverage
+        run: npm test -- --browsers=ChromeHeadless --watch=false --code-coverage
 
       - name: Check coverage thresholds
         run: |

--- a/.github/workflows/client-tests.yaml
+++ b/.github/workflows/client-tests.yaml
@@ -1,0 +1,32 @@
+name: client-tests
+on:
+  push:
+    paths:
+      - 'client/**'
+  pull_request:
+    paths:
+      - 'client/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./client
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: './client/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --browsers=ChromeHeadlessCI --watch=false
+        

--- a/.github/workflows/client-tests.yaml
+++ b/.github/workflows/client-tests.yaml
@@ -29,4 +29,4 @@ jobs:
         run: npm ci
 
       - name: Run tests
-        run: npm test -- --browsers=ChromeHeadlessCI --watch=false
+        run: npm test -- --browsers=ChromeHeadless --watch=false

--- a/.github/workflows/client-tests.yaml
+++ b/.github/workflows/client-tests.yaml
@@ -1,11 +1,9 @@
 name: client-tests
 on:
   push:
-    paths:
-      - 'client/**'
+    branches: [ "main" ]
   pull_request:
-    paths:
-      - 'client/**'
+    branches: [ "main" ]
 
 jobs:
   test:
@@ -29,4 +27,3 @@ jobs:
 
       - name: Run tests
         run: npm test -- --browsers=ChromeHeadlessCI --watch=false
-        

--- a/.github/workflows/client-tests.yaml
+++ b/.github/workflows/client-tests.yaml
@@ -22,6 +22,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: './client/package-lock.json'
 
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@latest
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/eslint-api.yaml
+++ b/.github/workflows/eslint-api.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   eslint:
-    name: Run eslint scanning
+    name: eslint scanning
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/eslint-client.yaml
+++ b/.github/workflows/eslint-client.yaml
@@ -20,7 +20,7 @@ on:
 
 jobs:
   eslint:
-    name: Run eslint scanning
+    name: eslint scanning
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/client/karma.conf.js
+++ b/client/karma.conf.js
@@ -1,0 +1,19 @@
+module.exports = function (config) {
+    config.set({
+      basePath: '',
+      frameworks: ['jasmine'],
+      plugins: [
+        'karma-chrome-launcher',
+        'karma-jasmine',
+        'karma-jasmine-html-reporter',
+      ],
+      client: {
+        clearContext: false,
+      },
+      browsers: ['ChromeHeadless'],
+      singleRun: true,
+      restartOnFileChange: true,
+      reporters: ['progress', 'kjhtml'],
+    });
+  };
+  

--- a/client/karma.conf.js
+++ b/client/karma.conf.js
@@ -1,3 +1,4 @@
+// karma.conf.js
 module.exports = function (config) {
     config.set({
       basePath: '',
@@ -10,32 +11,35 @@ module.exports = function (config) {
         require('@angular-devkit/build-angular/plugins/karma')
       ],
       client: {
-        clearContext: false
+        clearContext: false // leave Jasmine Spec Runner output visible in browser
       },
       coverageReporter: {
         dir: require('path').join(__dirname, './coverage'),
         subdir: '.',
         reporters: [
           { type: 'html' },
-          { type: 'text-summary' },
-          { type: 'json-summary' }
-        ],
-        check: {
-          global: {
-            statements: 90,
-            branches: 90,
-            functions: 90,
-            lines: 90
-          }
-        }
+          { type: 'text-summary' }
+        ]
       },
       reporters: ['progress', 'kjhtml', 'coverage'],
       port: 9876,
       colors: true,
       logLevel: config.LOG_INFO,
-      autoWatch: true,
-      browsers: ['ChromeHeadless'],
-      singleRun: false,
-      restartOnFileChange: true
+      autoWatch: false,
+      browsers: ['Chrome', 'ChromeHeadless'],
+      customLaunchers: {
+        ChromeHeadlessCI: {
+          base: 'ChromeHeadless',
+          flags: [
+            '--no-sandbox',
+            '--disable-gpu',
+            '--disable-dev-shm-usage',
+            '--remote-debugging-port=9222'
+          ]
+        }
+      },
+      singleRun: true,
+      restartOnFileChange: false
     });
   };
+  

--- a/client/karma.conf.js
+++ b/client/karma.conf.js
@@ -1,19 +1,41 @@
 module.exports = function (config) {
     config.set({
       basePath: '',
-      frameworks: ['jasmine'],
+      frameworks: ['jasmine', '@angular-devkit/build-angular'],
       plugins: [
-        'karma-chrome-launcher',
-        'karma-jasmine',
-        'karma-jasmine-html-reporter',
+        require('karma-jasmine'),
+        require('karma-chrome-launcher'),
+        require('karma-jasmine-html-reporter'),
+        require('karma-coverage'),
+        require('@angular-devkit/build-angular/plugins/karma')
       ],
       client: {
-        clearContext: false,
+        clearContext: false
       },
+      coverageReporter: {
+        dir: require('path').join(__dirname, './coverage'),
+        subdir: '.',
+        reporters: [
+          { type: 'html' },
+          { type: 'text-summary' },
+          { type: 'json-summary' }
+        ],
+        check: {
+          global: {
+            statements: 90,
+            branches: 90,
+            functions: 90,
+            lines: 90
+          }
+        }
+      },
+      reporters: ['progress', 'kjhtml', 'coverage'],
+      port: 9876,
+      colors: true,
+      logLevel: config.LOG_INFO,
+      autoWatch: true,
       browsers: ['ChromeHeadless'],
-      singleRun: true,
-      restartOnFileChange: true,
-      reporters: ['progress', 'kjhtml'],
+      singleRun: false,
+      restartOnFileChange: true
     });
   };
-  

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "test": "ng test --browsers=ChromeHeadless --watch=false --code-coverage",
+    "test": "ng test --no-watch --no-progress --browsers=ChromeHeadless --code-coverage",
     "lint": "ng lint"
   },
   "private": true,

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,7 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "test": "ng test",
+    "test": "ng test --browsers=ChromeHeadless --watch=false --code-coverage",
     "lint": "ng lint"
   },
   "private": true,


### PR DESCRIPTION
- Turn off running unit tests in the browser. All unit test results should show in the terminal
- Add code coverage results following unit test runs
- Add Github workflows requiring all unit tests to be passing and for code coverage to be >= 90%